### PR TITLE
Refactor auth for cookie-based sessions & add dark mode

### DIFF
--- a/AppEndHost/workspace/client/AppEndStudio/index.html
+++ b/AppEndHost/workspace/client/AppEndStudio/index.html
@@ -43,7 +43,6 @@
         </div>
     </div>
     <script src="/a..lib/append-all.js"></script>
-    <script src="/a..lib/append/js/append-auth.js"></script>
     <script src="assets/custom.js"></script>
     <script>
         $(document).ready(function () {

--- a/AppEndHost/workspace/client/a..lib/append-all-ltr.css
+++ b/AppEndHost/workspace/client/a..lib/append-all-ltr.css
@@ -441,8 +441,19 @@ html.os-html,html.os-html>.os-host{display:block;overflow:hidden;box-sizing:bord
     --text-color: var(--color-accent);
 }
 
-/* Force light mode - ignore system dark preference */
-html { color-scheme: light; }
+/* Dark Mode Support */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-bg: var(--fluent-neutral-900);
+        --color-bg-subtle: var(--fluent-neutral-800);
+        --color-bg-elevated: var(--fluent-neutral-800);
+        --color-text: var(--fluent-neutral-100);
+        --color-text-muted: var(--fluent-neutral-400);
+        --color-text-inverse: var(--fluent-neutral-900);
+        --color-border: var(--fluent-neutral-600);
+        --color-accent-subtle: var(--fluent-primary-900);
+    }
+}
 
 /* ====================================
    UTILITY CLASSES

--- a/AppEndHost/workspace/client/a..lib/append-all-rtl.css
+++ b/AppEndHost/workspace/client/a..lib/append-all-rtl.css
@@ -441,8 +441,19 @@ html.os-html,html.os-html>.os-host{display:block;overflow:hidden;box-sizing:bord
     --text-color: var(--color-accent);
 }
 
-/* Force light mode - ignore system dark preference */
-html { color-scheme: light; }
+/* Dark Mode Support */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-bg: var(--fluent-neutral-900);
+        --color-bg-subtle: var(--fluent-neutral-800);
+        --color-bg-elevated: var(--fluent-neutral-800);
+        --color-text: var(--fluent-neutral-100);
+        --color-text-muted: var(--fluent-neutral-400);
+        --color-text-inverse: var(--fluent-neutral-900);
+        --color-border: var(--fluent-neutral-600);
+        --color-accent-subtle: var(--fluent-primary-900);
+    }
+}
 
 /* ====================================
    UTILITY CLASSES

--- a/AppEndHost/workspace/client/a..lib/append/js/append-rpc.js
+++ b/AppEndHost/workspace/client/a..lib/append/js/append-rpc.js
@@ -1,32 +1,53 @@
 // append-rpc.js
 // RPC and Server Communication functions
 
+var _isRefreshing = false;
+var _pendingRequests = [];
+
 /**
  * 401 interceptor: on Unauthorized, try RefreshToken then retry or redirect to login
  */
 function handle401AndRetry(requests, options, RRs, workingObject) {
+    if (_isRefreshing) {
+        _pendingRequests.push({ requests: requests, options: options, RRs: RRs, workingObject: workingObject });
+        return;
+    }
+
+    _isRefreshing = true;
     var refreshOpts = normalizeOptions({ requests: [{ Method: "Zzz.AppEndProxy.RefreshToken", Inputs: {} }] });
     $.ajax(getRpcConf(refreshOpts.requests, true)).done(function (refreshRes) {
         try {
             var resp = Array.isArray(refreshRes) ? refreshRes[0] : refreshRes;
             if (resp && resp.IsSucceeded === true && resp.Result && resp.Result.Result === true) {
                 if (typeof setAsLogedIn === "function") setAsLogedIn();
-                // Do not call reGetLogedInUserContext here - avoids extra loading; existing userContext remains valid
                 executeRpcAjax(requests, options, RRs, workingObject, true);
+                
+                while (_pendingRequests.length > 0) {
+                    var pending = _pendingRequests.shift();
+                    executeRpcAjax(pending.requests, pending.options, pending.RRs, pending.workingObject, true);
+                }
             } else {
                 redirectToLogin();
+                _pendingRequests = [];
             }
         } catch (e) {
             redirectToLogin();
+            _pendingRequests = [];
         }
-    }).fail(function () {
-        redirectToLogin();
+        _isRefreshing = false;
+    }).fail(function (jqXhr) {
+        _isRefreshing = false;
+        _pendingRequests = [];
+        if (jqXhr.status === 401 || jqXhr.status === 403) {
+            redirectToLogin();
+        } else {
+            redirectToLogin();
+        }
     });
 }
 
 function redirectToLogin() {
     if (typeof setAsLogedOut === "function") setAsLogedOut();
-    window.location.reload();
 }
 
 function executeRpcAjax(requests, options, RRs, workingObject, isRetry) {


### PR DESCRIPTION
- Switch authentication to httpOnly cookie sessions; remove legacy token storage
- Update login/logout/session restore logic for cookie auth
- Add tryRestoreSessionFromCookie for session recovery on reload/new tab
- Always return safe user object to prevent template errors
- Send all RPC AJAX requests with credentials for cookie support
- Implement robust 401 handler: refresh token, retry, queue requests
- Add dark mode support via prefers-color-scheme in CSS
- Remove append-auth.js from index.html; merge into append-all.js
- Improve user settings and theme application logic